### PR TITLE
Add `modsem` package to Related Projects section

### DIFF
--- a/resources/related.qmd
+++ b/resources/related.qmd
@@ -23,6 +23,15 @@ A package to take into account survey weights, clustering, strata, and finite sa
 -   Website: <http://wp.daob.org/software/>
 -   CRAN: [lavaan.survey](http://cran.r-project.org/web/packages/lavaan.survey/index.html)
 
+#### modsem
+
+A package for estimating latent interaction and quadratic effects in structural equation models.
+
+-   Author(s): Kjell S Slupphaug
+-   Website: <https://modsem.org>
+-   CRAN: [modsem](https://CRAN.R-project.org/package=modsem)
+-   Github: [modsem development](https://github.com/kss2k/modsem)
+
 #### Onyx
 
 A graphical interface for Structural Equation Modeling.


### PR DESCRIPTION
I would like to suggest adding the [`modsem`](https://cran.r-project.org/package=modsem) package to the [Related Projects](https://lavaan.ugent.be/resources/related.html) section on the [lavaan website](https://lavaan.ugent.be/).

It seems like this isn't the latest version of the website, so this might not be correct place to request the addition. Please let me know if you want me to make the request in a different manor.